### PR TITLE
fix for getting null objects from Firebase

### DIFF
--- a/src/Mpociot/Firebase/SyncsWithFirebase.php
+++ b/src/Mpociot/Firebase/SyncsWithFirebase.php
@@ -63,7 +63,7 @@ trait SyncsWithFirebase
         if (is_null($this->firebaseClient)) {
             $this->firebaseClient = new FirebaseLib(config('services.firebase.database_url'), config('services.firebase.secret'));
         }
-        $path = $this->getTable() . '/' . $this->getKey();
+        $path = $this->getTable() . '/item' . $this->getKey();
 
         if ($mode === 'set') {
             $this->firebaseClient->set($path, $this->getFirebaseSyncData());


### PR DESCRIPTION
usually happened if you deleted some entries from Firebase database