### PR TITLE
Added manual synchronization method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
 

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         "source": "https://github.com/mpociot/laravel-firebase-sync"
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.0",
         "illuminate/support": "~5.0",
         "ktamas77/firebase-php": "^2.2"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",
         "orchestra/testbench": "~3.0",
-        "phpunit/phpunit": "~4.7 || ~5.0"
+        "phpunit/phpunit": "^5.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Mpociot/Firebase/SyncsWithFirebase.php
+++ b/src/Mpociot/Firebase/SyncsWithFirebase.php
@@ -31,9 +31,11 @@ trait SyncsWithFirebase
         static::deleted(function ($model) {
             $model->saveToFirebase('delete');
         });
-        static::restored(function ($model) {
-            $model->saveToFirebase('set');
-        });
+        if(in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses(self::class))){
+            static::restored(function ($model) {
+                $model->saveToFirebase('set');
+            });
+        }
     }
 
     /**

--- a/src/Mpociot/Firebase/SyncsWithFirebase.php
+++ b/src/Mpociot/Firebase/SyncsWithFirebase.php
@@ -56,6 +56,13 @@ trait SyncsWithFirebase
     }
 
     /**
+     * Manually sync to firebase
+     */
+    public function syncWithFirebase(){
+        $this->saveToFirebase('update');
+    }
+    
+    /**
      * @param $mode
      */
     protected function saveToFirebase($mode)

--- a/tests/FirebaseSyncTest.php
+++ b/tests/FirebaseSyncTest.php
@@ -46,7 +46,7 @@ class FirebaseSyncTest extends Orchestra\Testbench\TestCase
         $user->setFirebaseClient($firebaseStub);
         $user->save();
 
-        $this->seeInDatabase('users', [
+        $this->assertDatabaseHas('users', [
             'name' => 'Foo'
         ]);
     }
@@ -74,7 +74,7 @@ class FirebaseSyncTest extends Orchestra\Testbench\TestCase
         $user->name = 'Bar';
         $user->save();
 
-        $this->seeInDatabase('users', [
+        $this->assertDatabaseHas('users', [
             'name' => 'Bar'
         ]);
     }
@@ -101,7 +101,7 @@ class FirebaseSyncTest extends Orchestra\Testbench\TestCase
         $user->setFirebaseClient($firebaseStub);
         $user->delete();
 
-        $this->notSeeInDatabase('users', [
+        $this->assertDatabaseMissing('users', [
             'name' => 'Foo'
         ]);
     }


### PR DESCRIPTION
Added `syncWithFirebase` method that allows to manually sync the model with firebase;
usefull especially if you plan on customizing the return data with `getFirebaseSyncData` and using relations that needs to be updated from related models/events.